### PR TITLE
Feature/custom indexing

### DIFF
--- a/src/contexts/convert.ts
+++ b/src/contexts/convert.ts
@@ -1,0 +1,14 @@
+import { TypeMap } from '../evaluator';
+
+export const ConvertContext: TypeMap = {
+  toString,
+  toNumber,
+};
+
+function toString(value: any): string {
+  return String(value);
+}
+
+function toNumber(value: any): number {
+  return Number(value);
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export * from './math';
+export * from './string';

--- a/src/contexts/string.ts
+++ b/src/contexts/string.ts
@@ -1,0 +1,9 @@
+import { TypeMap } from '../evaluator';
+
+export const StringContext: TypeMap = {
+  regex,
+};
+
+function regex(pattern: string, flags?: string): RegExp {
+  return new RegExp(pattern, flags);
+}

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -391,8 +391,8 @@ export class ExpressionEvaluator {
     }
 
     if (this._memberChecks) {
-      for (const checkFn of this._memberChecks) {
-        if (checkFn(value.value, property.value)) {
+      for (const memberCheckFn of this._memberChecks) {
+        if (memberCheckFn(value.value, property.value)) {
           let val = (value.value as any)[property.value];
 
           // If the resolved value is a function, we need to bind it

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -393,8 +393,16 @@ export class ExpressionEvaluator {
     if (this._memberChecks) {
       for (const checkFn of this._memberChecks) {
         if (checkFn(value.value, property.value)) {
+          let val = (value.value as any)[property.value];
+
+          // If the resolved value is a function, we need to bind it
+          // to the object in order to preserve the 'this' reference.
+          if (typeof val === 'function') {
+            val = val.bind(value.value);
+          }
+
           return {
-            value: (value.value as any)[property.value],
+            value: val,
             nodes: 1 + value.nodes + property.nodes,
             functionCalls: value.functionCalls + property.functionCalls,
           };

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -374,7 +374,7 @@ export class ExpressionEvaluator {
   ): Promise<ExpressionResult> {
     const [value, property] = await Promise.all([
       this.evalExpression(expression.object),
-      expression.property.type === 'Identifier'
+      !expression.computed && expression.property.type === 'Identifier'
         ? {
             value: (expression.property as Identifier).name,
             nodes: 1,

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -41,7 +41,8 @@ export type ExpressionReturnType =
   | SimpleType
   | ArrayType
   | FunctionType
-  | TypeMap;
+  | TypeMap
+  | object;
 
 export interface ExpressionResult<T = ExpressionReturnType> {
   value: T;

--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -10,6 +10,8 @@ import {
   TypeMap,
 } from './expression-evaluator';
 
+export * from './member-checks';
+
 export {
   ArrayType,
   EvaluatorOptions,

--- a/src/evaluator/member-checks.ts
+++ b/src/evaluator/member-checks.ts
@@ -1,0 +1,78 @@
+import { ExpressionReturnType } from './expression-evaluator';
+
+/**
+ * Checks whether the identifier exists as an own property on the
+ * given object.
+ */
+export function objectOwnPropertyMemberCheck(
+  value: ExpressionReturnType,
+  ident: string | number,
+): boolean {
+  return (
+    typeof value === 'object' &&
+    Object.prototype.hasOwnProperty.call(value, ident)
+  );
+}
+
+const stringMethods = new Set([
+  'charAt',
+  'charCodeAt',
+  'codePointAt',
+  'concat',
+  'includes',
+  'endsWith',
+  'indexOf',
+  'lastIndexOf',
+  'localeCompare',
+  'match',
+  'matchAll',
+  'normalize',
+  'padEnd',
+  'padStart',
+  'repeat',
+  'replace',
+  'search',
+  'slice',
+  'split',
+  'startsWith',
+  'substring',
+  'toLocaleLowerCase',
+  'toLocaleUpperCase',
+  'toLowerCase',
+  'toUpperCase',
+  'trim',
+  'trimStart',
+  'trimLeft',
+  'trimEnd',
+  'trimRight',
+]);
+
+/**
+ * Checks whether the value is a string, and if so, whether the identifier
+ * is an allowed string method.
+ */
+export function stringMethodMemberCheck(
+  value: ExpressionReturnType,
+  ident: string | number,
+): boolean {
+  return (
+    typeof value === 'string' &&
+    typeof ident === 'string' &&
+    stringMethods.has(ident)
+  );
+}
+
+/**
+ * Checks whether the value is a string, and if so, whether the identifer
+ * can be used as a numeric index.
+ */
+export function stringIndexMemberCheck(
+  value: ExpressionReturnType,
+  ident: string | number,
+): boolean {
+  return (
+    typeof value === 'string' &&
+    typeof ident === 'number' &&
+    Object.prototype.hasOwnProperty.call(value, ident)
+  );
+}

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,3 +1,5 @@
+import { StringContext } from '../contexts';
+import { ConvertContext } from '../contexts/convert';
 import { MathContext } from '../contexts/math';
 import {
   Evaluator,
@@ -130,6 +132,8 @@ export class Rules {
           return ruleResult.value;
         },
         Math: MathContext,
+        String: StringContext,
+        Convert: ConvertContext,
         ...this.context,
         ...rule.context,
       },

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,5 +1,12 @@
 import { MathContext } from '../contexts/math';
-import { Evaluator, ExpressionReturnType, TypeMap } from '../evaluator';
+import {
+  Evaluator,
+  ExpressionReturnType,
+  objectOwnPropertyMemberCheck,
+  stringIndexMemberCheck,
+  stringMethodMemberCheck,
+  TypeMap,
+} from '../evaluator';
 import { DependencyGraph } from './dependency-graph';
 import { ResultListener } from './result-listener';
 
@@ -103,28 +110,37 @@ export class Rules {
     graph: DependencyGraph,
     resultListener: ResultListener<RuleResult>,
   ): Promise<RuleResult> {
-    const context = {
-      rule: async (targetId: string) => {
-        // Resolve aliases.
-        if (this.aliases) {
-          const alias = this.aliases.get(targetId);
+    const evaluator = new Evaluator({
+      // Build up context using custom functions and various defaults.
+      context: {
+        rule: async (targetId: string) => {
+          // Resolve aliases.
+          if (this.aliases) {
+            const alias = this.aliases.get(targetId);
 
-          if (alias !== undefined) {
-            targetId = alias;
+            if (alias !== undefined) {
+              targetId = alias;
+            }
           }
-        }
 
-        // First check if it will create a circular dependency.
-        // This throws an error if it will otherwise stores it.
-        graph.addDependency(id, targetId);
-        const ruleResult = await resultListener.wait(targetId);
-        return ruleResult.value;
+          // First check if it will create a circular dependency.
+          // This throws an error if it will otherwise stores it.
+          graph.addDependency(id, targetId);
+          const ruleResult = await resultListener.wait(targetId);
+          return ruleResult.value;
+        },
+        Math: MathContext,
+        ...this.context,
+        ...rule.context,
       },
-      Math: MathContext,
-      ...this.context,
-      ...rule.context,
-    };
-    const evaluator = new Evaluator({ context });
+      // Load in standard member checks.
+      memberChecks: [
+        objectOwnPropertyMemberCheck,
+        stringMethodMemberCheck,
+        stringIndexMemberCheck,
+      ],
+    });
+
     const evaluatorResult = await evaluator.eval(rule.expression);
     const value = evaluatorResult.value;
 

--- a/test/evaluator.spec.ts
+++ b/test/evaluator.spec.ts
@@ -1,4 +1,12 @@
-import { Evaluator, ExpressionReturnType } from '../src';
+import {
+  Evaluator,
+  ExpressionReturnType,
+  objectOwnPropertyMemberCheck,
+  stringIndexMemberCheck,
+  stringMethodMemberCheck,
+} from '../src';
+import { MathContext, StringContext } from '../src/contexts';
+import { ConvertContext } from '../src/contexts/convert';
 
 let evaluator: Evaluator;
 
@@ -15,49 +23,49 @@ beforeEach(() => {
 
 describe('Evaluator', () => {
   it('evaluates literals', async () => {
-    expect(await evl('1')).toBe(1);
-    expect(await evl('2')).toBe(2);
-    expect(await evl('3')).toBe(3);
-    expect(await evl('4')).toBe(4);
+    await expect(evl('1')).resolves.toBe(1);
+    await expect(evl('2')).resolves.toBe(2);
+    await expect(evl('3')).resolves.toBe(3);
+    await expect(evl('4')).resolves.toBe(4);
 
-    expect(await evl(`'a'`)).toBe('a');
-    expect(await evl(`'b'`)).toBe('b');
-    expect(await evl(`'c'`)).toBe('c');
-    expect(await evl(`'d'`)).toBe('d');
+    await expect(evl(`'a'`)).resolves.toBe('a');
+    await expect(evl(`'b'`)).resolves.toBe('b');
+    await expect(evl(`'c'`)).resolves.toBe('c');
+    await expect(evl(`'d'`)).resolves.toBe('d');
 
-    expect(await evl('[1, 2, 3]')).toEqual([1, 2, 3]);
-    expect(await evl('[2, 3, 1]')).toEqual([2, 3, 1]);
-    expect(await evl('[3, 2, 1]')).toEqual([3, 2, 1]);
-    expect(await evl('[9, 8, 7, 5]')).toEqual([9, 8, 7, 5]);
+    await expect(evl('[1, 2, 3]')).resolves.toEqual([1, 2, 3]);
+    await expect(evl('[2, 3, 1]')).resolves.toEqual([2, 3, 1]);
+    await expect(evl('[3, 2, 1]')).resolves.toEqual([3, 2, 1]);
+    await expect(evl('[9, 8, 7, 5]')).resolves.toEqual([9, 8, 7, 5]);
   });
 
   it('evaluates basic expressions', async () => {
-    expect(await evl('1 + 2')).toBe(1 + 2);
-    expect(await evl('2 + 4')).toBe(2 + 4);
-    expect(await evl('5 + 6')).toBe(5 + 6);
-    expect(await evl('7 + 8')).toBe(7 + 8);
+    await expect(evl('1 + 2')).resolves.toBe(1 + 2);
+    await expect(evl('2 + 4')).resolves.toBe(2 + 4);
+    await expect(evl('5 + 6')).resolves.toBe(5 + 6);
+    await expect(evl('7 + 8')).resolves.toBe(7 + 8);
 
-    expect(await evl('1 * 2')).toBe(1 * 2);
-    expect(await evl('2 * 4')).toBe(2 * 4);
-    expect(await evl('5 * 6')).toBe(5 * 6);
-    expect(await evl('7 * 8')).toBe(7 * 8);
+    await expect(evl('1 * 2')).resolves.toBe(1 * 2);
+    await expect(evl('2 * 4')).resolves.toBe(2 * 4);
+    await expect(evl('5 * 6')).resolves.toBe(5 * 6);
+    await expect(evl('7 * 8')).resolves.toBe(7 * 8);
 
-    expect(await evl('1 - 2')).toBe(1 - 2);
-    expect(await evl('2 - 4')).toBe(2 - 4);
-    expect(await evl('5 - 6')).toBe(5 - 6);
-    expect(await evl('7 - 8')).toBe(7 - 8);
+    await expect(evl('1 - 2')).resolves.toBe(1 - 2);
+    await expect(evl('2 - 4')).resolves.toBe(2 - 4);
+    await expect(evl('5 - 6')).resolves.toBe(5 - 6);
+    await expect(evl('7 - 8')).resolves.toBe(7 - 8);
 
-    expect(await evl('1 / 2')).toBeCloseTo(1 / 2);
-    expect(await evl('2 / 4')).toBeCloseTo(2 / 4);
-    expect(await evl('5 / 6')).toBeCloseTo(5 / 6);
-    expect(await evl('7 / 8')).toBeCloseTo(7 / 8);
+    await expect(evl('1 / 2')).resolves.toBeCloseTo(1 / 2);
+    await expect(evl('2 / 4')).resolves.toBeCloseTo(2 / 4);
+    await expect(evl('5 / 6')).resolves.toBeCloseTo(5 / 6);
+    await expect(evl('7 / 8')).resolves.toBeCloseTo(7 / 8);
 
-    expect(await evl('true ? 1 : 0')).toBe(1);
-    expect(await evl('false ? 1 : 0')).toBe(0);
+    await expect(evl('true ? 1 : 0')).resolves.toBe(1);
+    await expect(evl('false ? 1 : 0')).resolves.toBe(0);
 
-    expect(await evl('1, 2')).toBe(2);
-    expect(await evl('1, 2, 3')).toBe(3);
-    expect(await evl('1, 2, 3, 4')).toBe(4);
+    await expect(evl('1, 2')).resolves.toBe(2);
+    await expect(evl('1, 2, 3')).resolves.toBe(3);
+    await expect(evl('1, 2, 3, 4')).resolves.toBe(4);
   });
 
   it('evaluates identifiers', async () => {
@@ -68,7 +76,81 @@ describe('Evaluator', () => {
       d: 2,
     };
 
-    expect(await evl('a + b')).toBe('ab');
-    expect(await evl('c + d')).toBe(3);
+    await expect(evl('a + b')).resolves.toBe('ab');
+    await expect(evl('c + d')).resolves.toBe(3);
+  });
+});
+
+describe('Evaluator member checks', () => {
+  beforeEach(() => {
+    evaluator.options.context = {
+      l: (v: any) => v,
+      a: {
+        b: () => 'c',
+      },
+    };
+  });
+
+  it('handles no member checks', async () => {
+    await expect(evl('a.b()')).rejects.toThrow();
+    await expect(evl('l("abc")[0]')).rejects.toThrow();
+    await expect(evl('l(" a ").trim()')).rejects.toThrow();
+  });
+
+  it('handles object member checks', async () => {
+    evaluator.options.memberChecks = [objectOwnPropertyMemberCheck];
+
+    await expect(evl('a.b()')).resolves.toBe('c');
+    await expect(evl('l("abc")[0]')).rejects.toThrow();
+    await expect(evl('l(" a ").trim()')).rejects.toThrow();
+  });
+
+  it('handles string member checks', async () => {
+    evaluator.options.memberChecks = [stringIndexMemberCheck];
+
+    await expect(evl('a.b()')).rejects.toThrow();
+    await expect(evl('l("abc")[0]')).resolves.toBe('a');
+    await expect(evl('l(" a ").trim()')).rejects.toThrow();
+  });
+
+  it('handles string method member checks', async () => {
+    evaluator.options.memberChecks = [stringMethodMemberCheck];
+
+    await expect(evl('a.b()')).rejects.toThrow();
+    await expect(evl('l("abc")[0]')).rejects.toThrow();
+    await expect(evl('l(" a ").trim()')).resolves.toBe('a');
+  });
+});
+
+describe('Evaluator contexts', () => {
+  beforeEach(() => {
+    evaluator.options.memberChecks = [objectOwnPropertyMemberCheck];
+  });
+
+  it('has a correct math context', async () => {
+    evaluator.options.context = {
+      Math: MathContext,
+    };
+
+    await expect(evl('Math.abs(-1)')).resolves.toBe(1);
+  });
+
+  it('has a correct string context', async () => {
+    evaluator.options.context = {
+      String: StringContext,
+    };
+
+    await expect(evl('String.regex("abc")')).resolves.toEqual(/abc/);
+    await expect(evl('String.regex("abc", "g")')).resolves.toEqual(/abc/g);
+  });
+
+  it('has a correct convert context', async () => {
+    evaluator.options.context = {
+      Convert: ConvertContext,
+    };
+
+    await expect(evl('Convert.toString(1)')).resolves.toBe('1');
+    await expect(evl('Convert.toNumber("1")')).resolves.toBe(1);
+    await expect(evl('Convert.toNumber("a")')).resolves.toBeNaN();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,14 +17,8 @@
     "noUnusedParameters": true,
     "strict": true,
     "outDir": "./dist",
-    "alwaysStrict": true,
-    "baseUrl": ".",
+    "alwaysStrict": true
   },
-  "include": [
-    "src/**/*.ts",
-    "types/**/*.d.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*.ts", "types/**/*.d.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Adds the ability to use custom member checks instead of the hard-coded `hasOwnProperty` check. This allows members on the prototype to be accessed in a secure manner.

The own property check is available as a function, but is not enabled by default, meaning that it will default to the most secure instance. This means that, by default, only the top-level variables of the context are accessible. The rule engine has been updated to enable property access by default.

A couple of contexts have also been added 